### PR TITLE
52: [FEATURE] Add ExpenseRepo interface with required methods

### DIFF
--- a/hillel-expense-tracker-repo/src/main/java/ua/ithillel/expensetracker/repo/ExpenseRepo.java
+++ b/hillel-expense-tracker-repo/src/main/java/ua/ithillel/expensetracker/repo/ExpenseRepo.java
@@ -1,0 +1,57 @@
+package ua.ithillel.expensetracker.repo;
+
+import ua.ithillel.expensetracker.exception.ExpenseTrackerPersistingException;
+import ua.ithillel.expensetracker.model.Expense;
+import ua.ithillel.expensetracker.model.ExpenseCategory;
+import ua.ithillel.expensetracker.model.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExpenseRepo {
+
+    /**
+     * Finds an expense by ID
+     *
+     * @param id the ID of the expense
+     * @return an Optional containing the found expense ir empty if not found
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    Optional<Expense> find(Long id) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Saves an expense object
+     *
+     * @param expense the expense to save
+     * @return an Optional containing the saved expense
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    Optional<Expense> save(Expense expense) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Finds an expense by a user
+     *
+     * @param user the user whose expenses are to be retrieved
+     * @return a list of expense belonging to the user
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    List<Expense> findByUser(User user) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Finds an expense by a category
+     *
+     * @param category the category of the expense
+     * @return a list of expenses under the specified category
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    List<Expense> findByCategory(ExpenseCategory category) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Deletes an expense object
+     *
+     * @param expense the expense to delete
+     * @return an Optional containing the delete expense
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    Optional<Expense> delete(Expense expense) throws ExpenseTrackerPersistingException;
+}


### PR DESCRIPTION
## Describe your changes
- Created `ExpenseRepo` interface in the `repo` package
- Added methods to `ExpenseRepo`:
   - `find(Long id)`: Returns an Optional of Expense
   - `save(Expense expense)`: Saves and returns an Optional of Expense
   - `findByUser(User user)`: Returns a list of expenses for a given user
   - `findByCategory(ExpenseCategory category)`: Returns a list of expenses for a given category
   - `delete(Expense expense)`: Deletes an expense and returns an Optional of Expense
- Updated methods to throw `ExpenseTrackerPersistingException` for handling persisting errors

## Issue ticket number and link
Closes issue #52

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.