### PR TITLE
54: [FEATURE] Add ExpenseCategoryRepo interface with required methods

### DIFF
--- a/hillel-expense-tracker-repo/src/main/java/ua/ithillel/expensetracker/repo/ExpenseCategoryRepo.java
+++ b/hillel-expense-tracker-repo/src/main/java/ua/ithillel/expensetracker/repo/ExpenseCategoryRepo.java
@@ -1,0 +1,50 @@
+package ua.ithillel.expensetracker.repo;
+
+import ua.ithillel.expensetracker.exception.ExpenseTrackerPersistingException;
+import ua.ithillel.expensetracker.model.ExpenseCategory;
+import ua.ithillel.expensetracker.model.User;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for managing Expense Category repository operations.
+ */
+public interface ExpenseCategoryRepo {
+
+    /**
+     * Finds an expense category by ID
+     *
+     * @param id the ID of the expense category
+     * @return an Optional containing the found expense category or empty if not found
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    Optional<ExpenseCategory> find(Long id) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Saves an expense category object
+     *
+     * @param expenseCategory the expense category to save
+     * @return an Optional containing the saved expense category
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    Optional<ExpenseCategory> save(ExpenseCategory expenseCategory) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Finds expense categories by a user
+     *
+     * @param user the user whose expense categories are to be retrieved
+     * @return a list of expense categories belonging to the user
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    List<ExpenseCategory> findByUser(User user) throws ExpenseTrackerPersistingException;
+
+    /**
+     * Deletes an expense category object
+     *
+     * @param expenseCategory the expense category to delete
+     * @return an Optional containing the deleted expense category
+     * @throws ExpenseTrackerPersistingException if any persisting error occurs
+     */
+    Optional<ExpenseCategory> delete(ExpenseCategory expenseCategory) throws ExpenseTrackerPersistingException;
+}


### PR DESCRIPTION
## Describe your changes
- Created `ExpenseCategoryRepo` interface in the `repo` package
- Added the following methods:
   - `find(Long id)`: Returns an Optional of ExpenseCategory
   - `save(ExpenseCategory expenseCategory)`: Saves and returns an Optional of ExpenseCategory
   - `findByUser(User user)`: Retrieves a list of ExpenseCategory objects for a specific user
   - `delete(ExpenseCategory expenseCategory)`: Deletes an ExpenseCategory and returns an Optional of the deleted object
- All methods throw `ExpenseTrackerPersistingException` for error handling

## Issue ticket number and link
Closes issue #54 

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.